### PR TITLE
Install and enable igv.js nbextension automatically with PIP install

### DIFF
--- a/igv.json
+++ b/igv.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "igv/extension": true
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,22 @@
 import setuptools
+import os
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+    
+def get_extension_files():
+    """
+    Move the files to the nbextensions directory and enable the extension
+    """
+    return [
+        ('share/jupyter/nbextensions/igv', [
+            'igv/static/extension.js',
+        ]),
+        ('share/jupyter/nbextensions/igv/igvjs',
+         ['igv/static/igvjs/' + f for f in os.listdir('igv/static/igvjs')]
+         ),
+        ('etc/jupyter/nbconfig/notebook.d', ['igv.json']),
+    ]
 
 setuptools.setup(name='igv',
                  packages=['igv'],
@@ -23,4 +38,5 @@ setuptools.setup(name='igv',
                      'Framework :: IPython',
                  ],
                  package_data={'igv': ['static/extension.js', 'static/igvjs/*']},
+                 data_files=get_extension_files(),
                  )


### PR DESCRIPTION
This creates an `igv.json` file which is placed at `etc/jupyter/nbconfig/notebook.d/igv.json`. This file tells Jupyter to automatically load the igv nbextension. 

It also also automatically installs the nbextension when the Python package is PIP installed by moving the Javascript files to `share/jupyter/nbextensions/igv`.