### PR TITLE
Align jupyterlab requirement with README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        "jupyterlab~=3.0",
+        "jupyterlab>=3.0",
         "ipywidgets>=7.0.0",
         "igv-notebook",
     ],


### PR DESCRIPTION
README states `jupyterlab >= 3.0`. Let that reflect in setup.py as well.

Fixes https://github.com/g2nb/igv-jupyter/issues/52